### PR TITLE
Fix for validator bug.

### DIFF
--- a/src/He.PipelineAssessment.UI.Tests/Features/Workflow/SaveAndContinue/SaveAndContinueCommandValidatorTests.cs
+++ b/src/He.PipelineAssessment.UI.Tests/Features/Workflow/SaveAndContinue/SaveAndContinueCommandValidatorTests.cs
@@ -1,4 +1,5 @@
-﻿using Elsa.CustomWorkflow.Sdk.Models.Workflow;
+﻿using Elsa.CustomWorkflow.Sdk;
+using Elsa.CustomWorkflow.Sdk.Models.Workflow;
 using FluentValidation.TestHelper;
 using He.PipelineAssessment.UI.Features.Workflow.SaveAndContinue;
 using Xunit;
@@ -18,6 +19,7 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
         [AutoMoqData]
         public void Should_Have_Error_When_Multiple_Exclusive_Choices_Selected(SaveAndContinueCommand saveAndContinueCommand)
         {
+            //Arrange
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.Choices =  new List<Choice>
             {
                 new Choice
@@ -41,9 +43,11 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
                     IsSingle = true
                    },
             };
+            saveAndContinueCommand.Data.QuestionActivityData!.ActivityType = ActivityTypeConstants.MultipleChoiceQuestion;
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.SelectedChoices = new List<string>() { "Test 1", "Test 2", "Test 4" };
-
+            //Act
             var result = this._validator.TestValidate(saveAndContinueCommand);
+            //Assert
             result.ShouldHaveValidationErrorFor(c=> c.Data.QuestionActivityData!.MultipleChoice)
                 .WithErrorMessage("Test 1, Test 2 and Test 4 cannot be selected with any other answer.");
         }
@@ -52,6 +56,7 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
         [AutoMoqData]
         public void Should_Have_Error_When_Exclusive_And_Nonexclusive_Choices_Selected(SaveAndContinueCommand saveAndContinueCommand)
         {
+            //Arrange
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.Choices = new List<Choice>
             {
                 new Choice
@@ -70,9 +75,14 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
                     IsSingle = true
                    },
             };
+            saveAndContinueCommand.Data.QuestionActivityData!.ActivityType = ActivityTypeConstants.MultipleChoiceQuestion;
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.SelectedChoices = new List<string>() { "Test 1", "Test 2" };
 
+            //Act
             var result = this._validator.TestValidate(saveAndContinueCommand);
+
+            //Assert
+
             result.ShouldHaveValidationErrorFor(c => c.Data.QuestionActivityData!.MultipleChoice)
                 .WithErrorMessage("Test 1 cannot be selected with any other answer.");
         }
@@ -81,6 +91,7 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
         [AutoMoqData]
         public void Should_Not_Have_Error_When_Single_Exclusive_Choice_Selected(SaveAndContinueCommand saveAndContinueCommand)
         {
+            //Arrange
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.Choices = new List<Choice>
             {
                 new Choice
@@ -99,9 +110,13 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
                     IsSingle = true
                    },
             };
+            saveAndContinueCommand.Data.QuestionActivityData!.ActivityType = ActivityTypeConstants.MultipleChoiceQuestion;
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.SelectedChoices = new List<string>() { "Test 1" };
 
+            //Act
             var result = this._validator.TestValidate(saveAndContinueCommand);
+
+            //Assert
             result.ShouldNotHaveValidationErrorFor(c => c.Data.QuestionActivityData!.MultipleChoice);
         }
 
@@ -109,6 +124,7 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
         [AutoMoqData]
         public void Should_Not_Have_Error_When_Multiple_Nonexclusive_Choices_Selected(SaveAndContinueCommand saveAndContinueCommand)
         {
+            //Arrange
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.Choices = new List<Choice>
             {
                 new Choice
@@ -127,9 +143,13 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
                     IsSingle = false
                    },
             };
+            saveAndContinueCommand.Data.QuestionActivityData!.ActivityType = ActivityTypeConstants.MultipleChoiceQuestion;
             saveAndContinueCommand.Data.QuestionActivityData!.MultipleChoice.SelectedChoices = new List<string>() { "Test 2", "Test 3" };
 
+            //Act
             var result = this._validator.TestValidate(saveAndContinueCommand);
+
+            //Assert
             result.ShouldNotHaveValidationErrorFor(c => c.Data.QuestionActivityData!.MultipleChoice);
         }
     }

--- a/src/He.PipelineAssessment.UI/Features/Workflow/SaveAndContinue/SaveAndContinueCommandValidator.cs
+++ b/src/He.PipelineAssessment.UI/Features/Workflow/SaveAndContinue/SaveAndContinueCommandValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using Elsa.CustomWorkflow.Sdk;
+using FluentValidation;
 
 namespace He.PipelineAssessment.UI.Features.Workflow.SaveAndContinue
 {
@@ -18,7 +19,8 @@ namespace He.PipelineAssessment.UI.Features.Workflow.SaveAndContinue
                     }
                 }
                 return true;
-            }).WithMessage(x =>
+            }).When(x => x.Data.QuestionActivityData!.ActivityType == ActivityTypeConstants.MultipleChoiceQuestion)
+                .WithMessage(x =>
             {
                 var selectedAnswers = x.Data.QuestionActivityData!.MultipleChoice.SelectedChoices;
                 var exclusiveAnswers = x.Data.QuestionActivityData.MultipleChoice.Choices


### PR DESCRIPTION
Spotted a bug when submitting a non-multi-choice question.  As we did not put a condition on the validator, it was attempting to run the validation against every activity type, as opposed to just the multi-choice activity type.

Added the When() stipulation to check against the activity type, which seems to have resolved the issue.  Putting in as an immediate bugfix, and will add additional tests in due course.