### PR TITLE
Bugfix/save and continue validator

### DIFF
--- a/src/Elsa.CustomActivities.Tests/Activities/Shared/QuestionBookmarkProviderTests.cs
+++ b/src/Elsa.CustomActivities.Tests/Activities/Shared/QuestionBookmarkProviderTests.cs
@@ -11,6 +11,7 @@ namespace Elsa.CustomActivities.Tests.Activities.Shared
         [Theory]
         [InlineAutoMoqData(Constants.CurrencyQuestion)]
         [InlineAutoMoqData(Constants.MultipleChoiceQuestion)]
+        [InlineAutoMoqData(Constants.SingleChoiceQuestion)]
         [InlineAutoMoqData(Constants.DateQuestion)]
         [InlineAutoMoqData(Constants.TextQuestion)]
         public void SupportsActivityReturnsTrue_GivenRegisteredActivities(string registeredActivity, QuestionBookmarkProvider sut)

--- a/src/He.PipelineAssessment.UI.Tests/Features/Workflow/SaveAndContinue/SaveAndContinueCommandValidatorTests.cs
+++ b/src/He.PipelineAssessment.UI.Tests/Features/Workflow/SaveAndContinue/SaveAndContinueCommandValidatorTests.cs
@@ -152,5 +152,23 @@ namespace He.PipelineAssessment.UI.Tests.Features.Workflow.SaveAndContinue
             //Assert
             result.ShouldNotHaveValidationErrorFor(c => c.Data.QuestionActivityData!.MultipleChoice);
         }
+
+        [Theory]
+        [AutoMoqData]
+        [InlineAutoMoqData(ActivityTypeConstants.CurrencyQuestion)]
+        [InlineAutoMoqData(ActivityTypeConstants.SingleChoiceQuestion)]
+        [InlineAutoMoqData(ActivityTypeConstants.DateQuestion)]
+        [InlineAutoMoqData(ActivityTypeConstants.TextQuestion)]
+        public void Should_not_check_for_multiple_choice_validation_when_not_multiple_choice_activity(string activityType, SaveAndContinueCommand saveAndContinueCommand)
+        {
+            //Arrange
+            saveAndContinueCommand.Data.QuestionActivityData!.ActivityType = activityType;
+
+            //Act
+            var result = this._validator.TestValidate(saveAndContinueCommand);
+
+            //Assert
+            result.ShouldNotHaveValidationErrorFor(c => c.Data.QuestionActivityData!.MultipleChoice);
+        }
     }
 }


### PR DESCRIPTION
Added an additional unit test to confirm that the multiple-choice rules were not applied, when the activity type being validated was not the multiple choice activity.