### PR TITLE
Bugfix/paragraphs not working on confirmation

### DIFF
--- a/src/Elsa.CustomActivities/Activities/QuestionScreen/Question.cs
+++ b/src/Elsa.CustomActivities/Activities/QuestionScreen/Question.cs
@@ -198,7 +198,10 @@ namespace Elsa.CustomActivities.Activities.QuestionScreen
             ExpectedOutputType = ExpectedOutputHints.WeightedCheckbox)]
         public WeightedCheckboxModel WeightedCheckbox { get; set; } = new WeightedCheckboxModel();
 
-        [HeActivityInput(UIHint = HePropertyUIHints.TextActivity, ConditionalActivityTypes = new[] { QuestionTypeConstants.Information }, ExpectedOutputType = ExpectedOutputHints.TextActivity)]
+        [HeActivityInput(UIHint = HePropertyUIHints.TextActivity, 
+            DefaultSyntax = TextActivitySyntaxNames.TextActivity,
+            ConditionalActivityTypes = new[] { QuestionTypeConstants.Information }, 
+            ExpectedOutputType = ExpectedOutputHints.TextActivity)]
         public TextModel Text { get; set; } = new TextModel();
 
         [HeActivityInput(Hint = "Fill in to display a pre-populated value", UIHint = HePropertyUIHints.SingleLine,

--- a/src/Elsa.Dashboard/src/components/base-component.ts
+++ b/src/Elsa.Dashboard/src/components/base-component.ts
@@ -28,6 +28,9 @@ export class BaseComponent {
   constructor(public component: ISharedComponent) { }
 
   componentWillLoad() {
+    if (this.component.propertyDescriptor.defaultSyntax != null && this.component.propertyDescriptor.defaultSyntax != undefined) {
+      this.component.modelSyntax = this.component.propertyDescriptor.defaultSyntax;
+    }
     const propertyModel = this.component.propertyModel;
     const modelJson = propertyModel.expressions[this.component.modelSyntax]
     this.component.properties = parseJson(modelJson) || [];

--- a/src/Elsa.Dashboard/src/components/common-properties/he-text-activity-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-text-activity-property.tsx
@@ -25,7 +25,7 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
   @Prop() activityModel: ActivityModel;
   @Prop() propertyDescriptor: ActivityPropertyDescriptor;
   @Prop() propertyModel: ActivityDefinitionProperty;
-  @Prop() modelSyntax: string = SyntaxNames.Json;
+  @Prop() modelSyntax: string = SyntaxNames.TextActivity;
   @State() properties: Array<NestedActivityDefinitionProperty> = [];
   @State() iconProvider = new IconProvider();
   @State() keyId: string;
@@ -45,11 +45,15 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
   hiddenValue: string = "none";
 
   constructor() {
+    if (this.propertyDescriptor.defaultSyntax != null && this.propertyDescriptor.defaultSyntax != undefined) {
+      this.modelSyntax = this.propertyDescriptor.defaultSyntax;
+    }
     this._base = new SortableComponent(this);
     this._toggle = new DisplayToggle(this);
   }
 
   async componentWillLoad() {
+    console.log("Syntax", this.propertyDescriptor.defaultSyntax);
     this._base.componentWillLoad();
   }
 

--- a/src/Elsa.Dashboard/src/components/common-properties/he-text-activity-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-text-activity-property.tsx
@@ -45,9 +45,6 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
   hiddenValue: string = "none";
 
   constructor() {
-    if (this.propertyDescriptor.defaultSyntax != null && this.propertyDescriptor.defaultSyntax != undefined) {
-      this.modelSyntax = this.propertyDescriptor.defaultSyntax;
-    }
     this._base = new SortableComponent(this);
     this._toggle = new DisplayToggle(this);
   }

--- a/src/Elsa.Dashboard/src/constants/constants.ts
+++ b/src/Elsa.Dashboard/src/constants/constants.ts
@@ -12,6 +12,7 @@ export class SyntaxNames {
   static readonly TextActivity = 'TextActivity';
   static readonly DataDictionary = 'DataDictionary';
   static readonly DataTable = 'DataTable';
+  static readonly InformationText = 'TextActivity';
   static Variable: string;
   static Output: string;
 }


### PR DESCRIPTION
Fixed the shared base component to ensure that the correct syntax was selected on component load.  Previously the syntax was incorrect for the TextActivity as was defaulting to JSON rather than the TextActivity syntax.

Co-authored-by: Jerry Zajac [32240008+jarekzaj@users.noreply.github.com](mailto:32240008+jarekzaj@users.noreply.github.com)
Co-authored-by: Jonny T [90678699+Jonnythan-t@users.noreply.github.com](mailto:90678699+Jonnythan-t@users.noreply.github.com)
Co-authored-by: Lorna B [93874097+lornacbirchall@users.noreply.github.com](mailto:93874097+lornacbirchall@users.noreply.github.com)
Co-authored-by: Rob Ryan [112186767+rryan0088@users.noreply.github.com](mailto:112186767+rryan0088@users.noreply.github.com)