### PR TITLE
Adding AntiforgeryToken Config.

### DIFF
--- a/src/He.PipelineAssessment.UI/Program.cs
+++ b/src/He.PipelineAssessment.UI/Program.cs
@@ -127,6 +127,12 @@ builder.Services.AddSinglePipelineClient(builder.Configuration, builder.Environm
 builder.AddCustomAuth0Configuration();
 builder.Services.AddCustomAuthentication();
 
+builder.Services.AddAntiforgery(options =>
+{
+    options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+    options.Cookie.HttpOnly = true;
+});
+
 var app = builder.Build();
 
 


### PR DESCRIPTION
Following feedback from OWASP checks, added in AntiForgeryToken configuration to enable Secure Cookie policies for AntiforgeryTokens.

Co-authored-by: Jerry Zajac [32240008+jarekzaj@users.noreply.github.com](mailto:32240008+jarekzaj@users.noreply.github.com)
Co-authored-by: Jonny T [90678699+Jonnythan-t@users.noreply.github.com](mailto:90678699+Jonnythan-t@users.noreply.github.com)
Co-authored-by: Lorna B [93874097+lornacbirchall@users.noreply.github.com](mailto:93874097+lornacbirchall@users.noreply.github.com)
Co-authored-by: Rob Ryan [112186767+rryan0088@users.noreply.github.com](mailto:112186767+rryan0088@users.noreply.github.com)