### PR TITLE
Fix for TLS configuration

### DIFF
--- a/src/Elsa.Server/Extensions/ElsaStartupExtensions.cs
+++ b/src/Elsa.Server/Extensions/ElsaStartupExtensions.cs
@@ -60,7 +60,7 @@ namespace Elsa.Server.Extensions
             configurationOptions.CertificateValidation += CertificateValidationCallBack!;
             configurationOptions.CertificateSelection += OptionsOnCertificateSelection;
             configurationOptions.Ssl = true;
-            configurationOptions.SslProtocols = SslProtocols.Tls12;
+            configurationOptions.SslProtocols = SslProtocols.Tls13;
             configurationOptions.AbortOnConnectFail = false;
             var connectionMultiplexer = (IConnectionMultiplexer)ConnectionMultiplexer.Connect(configurationOptions);
             return services.AddSingleton(connectionMultiplexer);


### PR DESCRIPTION
Fix for TLS configuration to enable Redis connections in the cluster.  TLS configuration was using an incorrect value, and was not compatible with the version used by the resource.  