### PR TITLE
Fix for displaying text on Confirmation screen

### DIFF
--- a/src/He.PipelineAssessment.UI/Features/Workflow/LoadConfirmationScreen/LoadConfirmationScreenResponse.cs
+++ b/src/He.PipelineAssessment.UI/Features/Workflow/LoadConfirmationScreen/LoadConfirmationScreenResponse.cs
@@ -7,6 +7,6 @@ namespace He.PipelineAssessment.UI.Features.Workflow.LoadConfirmationScreen
         public bool IsLatestSubmittedWorkflow { get; set; }
         public bool IsAmendableWorkflow { get; set; }
         public bool IsVariationAllowed { get; set; }
-        public bool IsAuthorised { get; set; }
+        public bool IsAuthorised { get; set; } = true;
     }
 }


### PR DESCRIPTION
Bug detected that prevents users from proceeding to the confirmation screen.  This was due to the new IsAuthenticated property as part of the Sensitive Records work.

Minor fix to set the "IsAuthorised" property to default to true for the Confirmation Screen.  Checks are performed in the handler to set it to false by action, so I have inferred that it should be set to true as its baseline.

