### PR TITLE
Css and Html Changes

### DIFF
--- a/src/Elsa.Dashboard/src/components/common-properties/custom-switch.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/custom-switch.tsx
@@ -118,7 +118,7 @@ export class CustomElsaSwitchCasesProperty {
           </td>
           <td class="elsa-py-2 pl-5">
 
-            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
               <he-expression-editor
                 key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                 ref={el => expressionEditor = el}
@@ -132,7 +132,7 @@ export class CustomElsaSwitchCasesProperty {
               />
               <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                 <select onChange={e => this.onCaseSyntaxChanged(e, switchCase, expressionEditor)}
-                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                   {supportedSyntaxes.map(supportedSyntax => {
                     const selected = supportedSyntax == syntax;
                     return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-checkbox-option-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-checkbox-option-property.tsx
@@ -154,7 +154,7 @@ export class HeCheckboxOptionProperty implements ISortableSharedComponent, IDisp
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Answer</th>
 
             <td class="elsa-py-2 pl-5" colSpan={ 2 } style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${checkboxOption.name}-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => expressionEditor = el}
@@ -167,7 +167,7 @@ export class HeCheckboxOptionProperty implements ISortableSharedComponent, IDisp
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, checkboxOption, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == syntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -200,7 +200,7 @@ export class HeCheckboxOptionProperty implements ISortableSharedComponent, IDisp
           <tr style={{ display: optionsDisplay }} >
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre Populated</th>
             <td class="elsa-py-2 pl-5" style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => prePopulatedExpressionEditor = el}
@@ -213,7 +213,7 @@ export class HeCheckboxOptionProperty implements ISortableSharedComponent, IDisp
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateCheckbox(e, checkboxOption, prePopulatedExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                       return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-data-table-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-data-table-property.tsx
@@ -169,7 +169,7 @@ export class HeDataTableProperty implements ISortableSharedComponent, IDisplayTo
               class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Row Heading
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
 
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
@@ -183,7 +183,7 @@ export class HeDataTableProperty implements ISortableSharedComponent, IDisplayTo
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, tableInput, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == syntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -236,7 +236,7 @@ export class HeDataTableProperty implements ISortableSharedComponent, IDisplayTo
                 class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre-Populated Input
             </th>
             <td class="elsa-py-2 elsa-w-10/12" colSpan={2} style={{ width: colWidth }}>
-            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
               <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => expressionEditor = el}
@@ -249,7 +249,7 @@ export class HeDataTableProperty implements ISortableSharedComponent, IDisplayTo
               />
               <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, tableInput, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                     return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-potscore-radio-option-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-potscore-radio-option-property.tsx
@@ -168,7 +168,7 @@ export class HePotScoreRadioOptionProperty implements ISortableSharedComponent, 
               class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Answer
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => expressionEditor = el}
@@ -181,7 +181,7 @@ export class HePotScoreRadioOptionProperty implements ISortableSharedComponent, 
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioOption, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == syntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -219,7 +219,7 @@ export class HePotScoreRadioOptionProperty implements ISortableSharedComponent, 
           <tr style={{ display: optionsDisplay }}>
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre Populated</th>
             <td class="elsa-py-2" style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => prePopulatedExpressionEditor = el}
@@ -232,7 +232,7 @@ export class HePotScoreRadioOptionProperty implements ISortableSharedComponent, 
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioOption, prePopulatedExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                       return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-radio-option-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-radio-option-property.tsx
@@ -155,7 +155,7 @@ export class HeRadioOptionProperty implements ISortableSharedComponent, IDisplay
                 class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Answer
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
               <he-expression-editor
                 key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                 ref={el => expressionEditor = el}
@@ -168,7 +168,7 @@ export class HeRadioOptionProperty implements ISortableSharedComponent, IDisplay
               />
               <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                 <select onChange={e => this._base.UpdateSyntax(e, radioOption, expressionEditor)}
-                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                   {supportedSyntaxes.map(supportedSyntax => {
                     const selected = supportedSyntax == syntax;
                     return <option selected={selected}>{supportedSyntax}</option>;
@@ -190,7 +190,7 @@ export class HeRadioOptionProperty implements ISortableSharedComponent, IDisplay
           <tr style={{ display: optionsDisplay }}>
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre Populated</th>
             <td class="elsa-py-2 pl-5" style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => prePopulatedExpressionEditor = el}
@@ -203,7 +203,7 @@ export class HeRadioOptionProperty implements ISortableSharedComponent, IDisplay
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioOption, prePopulatedExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                       return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-text-activity-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-text-activity-property.tsx
@@ -166,7 +166,7 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
             <th class="elsa-px-6 elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Text
             </th>
             <td class="elsa-py-2 pl-5" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
               <he-expression-editor
                 key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                 ref={el => textExpressionEditor = el}
@@ -180,7 +180,7 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, nestedTextActivity, textExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == textSyntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -201,7 +201,7 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
                 class="elsa-px-6 elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Display on Page
             </th>
             <td class="elsa-py-2 pl-5" colSpan={2} style={{ width: colWidth }}>
-                <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                   <he-expression-editor
                     key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                     ref={el => conditionExpressionEditor = el}
@@ -214,7 +214,7 @@ export class TextActivityProperty implements ISortableSharedComponent, IDisplayT
                   />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, nestedTextActivity, conditionExpressionEditor)}
-                      class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                       {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                         const selected = supportedSyntax == SyntaxNames.JavaScript;
                         return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-weighted-checkbox-option-group-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-weighted-checkbox-option-group-property.tsx
@@ -199,7 +199,7 @@ export class HeWeightedCheckboxOptionGroupProperty implements ISortableSharedCom
               class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Answer
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                   ref={el => expressionEditor = el}
@@ -212,7 +212,7 @@ export class HeWeightedCheckboxOptionGroupProperty implements ISortableSharedCom
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, checkboxAnswer, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == syntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -228,7 +228,7 @@ export class HeWeightedCheckboxOptionGroupProperty implements ISortableSharedCom
               Score
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.scoreSyntaxSwitchCount}-${this.keyId}`}
                   ref={el => scoreExpressionEditor = el}
@@ -241,7 +241,7 @@ export class HeWeightedCheckboxOptionGroupProperty implements ISortableSharedCom
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, checkboxAnswer, scoreExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.Literal).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.Literal;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -284,7 +284,7 @@ export class HeWeightedCheckboxOptionGroupProperty implements ISortableSharedCom
           <tr style={{ display: optionsDisplay }}>
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre Populated</th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
 
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
@@ -298,7 +298,7 @@ export class HeWeightedCheckboxOptionGroupProperty implements ISortableSharedCom
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, checkboxAnswer, prePopulatedExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                       return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-weighted-radio-option-group-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-weighted-radio-option-group-property.tsx
@@ -165,7 +165,7 @@ export class HeWeightedRadioOptionGroupProperty implements ISortableSharedCompon
               Answer
             </th>
             <td class="elsa-py-2 pl-5" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                   ref={el => expressionEditor = el}
@@ -178,7 +178,7 @@ export class HeWeightedRadioOptionGroupProperty implements ISortableSharedCompon
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioAnswer, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == syntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -194,7 +194,7 @@ export class HeWeightedRadioOptionGroupProperty implements ISortableSharedCompon
               Score
             </th>
             <td class="elsa-py-2 pl-5" style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.scoreSyntaxSwitchCount}`}
                   ref={el => scoreExpressionEditor = el}
@@ -207,7 +207,7 @@ export class HeWeightedRadioOptionGroupProperty implements ISortableSharedCompon
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioAnswer, scoreExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.Literal).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.Literal;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -230,7 +230,7 @@ export class HeWeightedRadioOptionGroupProperty implements ISortableSharedCompon
           <tr style={{ display: optionsDisplay }}>
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre Populated</th>
             <td class="elsa-py-2 pl-5" style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                   ref={el => prePopulatedExpressionEditor = el}
@@ -243,7 +243,7 @@ export class HeWeightedRadioOptionGroupProperty implements ISortableSharedCompon
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioAnswer, prePopulatedExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                       return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/he-weighted-radio-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/he-weighted-radio-property.tsx
@@ -157,7 +157,7 @@ export class HeWeightedRadioProperty implements ISortableSharedComponent, IDispl
               class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Answer
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                   ref={el => expressionEditor = el}
@@ -170,7 +170,7 @@ export class HeWeightedRadioProperty implements ISortableSharedComponent, IDispl
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioOption, expressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {supportedSyntaxes.map(supportedSyntax => {
                       const selected = supportedSyntax == syntax;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -185,7 +185,7 @@ export class HeWeightedRadioProperty implements ISortableSharedComponent, IDispl
               Score
             </th>
             <td class="elsa-py-2" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.scoreSyntaxSwitchCount}`}
                   ref={el => scoreExpressionEditor = el}
@@ -198,7 +198,7 @@ export class HeWeightedRadioProperty implements ISortableSharedComponent, IDispl
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioOption, scoreExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.Literal).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.Literal;
                       return <option selected={selected}>{supportedSyntax}</option>;
@@ -218,7 +218,7 @@ export class HeWeightedRadioProperty implements ISortableSharedComponent, IDispl
           <tr style={{ display: optionsDisplay }}>
             <th class="elsa-py-3 elsa-text-left elsa-text-xs elsa-font-medium elsa-text-gray-500 elsa-tracking-wider elsa-w-2/12">Pre Populated</th>
             <td class="elsa-py-2 pl-5" colSpan={2} style={{ width: colWidth }}>
-              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+              <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
                 <he-expression-editor
                   key={`expression-editor-${index}-${this.syntaxSwitchCount}`}
                   ref={el => prePopulatedExpressionEditor = el}
@@ -231,7 +231,7 @@ export class HeWeightedRadioProperty implements ISortableSharedComponent, IDispl
                 />
                 <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                   <select onChange={e => this._base.UpdateSyntax(e, radioOption, prePopulatedExpressionEditor)}
-                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                    class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                     {this.supportedSyntaxes.filter(x => x == SyntaxNames.JavaScript).map(supportedSyntax => {
                       const selected = supportedSyntax == SyntaxNames.JavaScript;
                       return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/nested-elsa/he-check-list-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/nested-elsa/he-check-list-property.tsx
@@ -131,7 +131,7 @@ export class HEChecklistProperty {
           </td>
           <td class="elsa-py-2 pl-5">
 
-            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
               <he-expression-editor
                 key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                 ref={el => expressionEditor = el}
@@ -144,7 +144,7 @@ export class HEChecklistProperty {
               />
               <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                 <select onChange={e => this.onCaseSyntaxChanged(e, switchCase, expressionEditor)}
-                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                   {supportedSyntaxes.map(supportedSyntax => {
                     const selected = supportedSyntax == syntax;
                     return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/src/components/common-properties/nested-elsa/he-switch-cases-property.tsx
+++ b/src/Elsa.Dashboard/src/components/common-properties/nested-elsa/he-switch-cases-property.tsx
@@ -144,7 +144,7 @@ export class HeSwitchCasesProperty {
           </td>
           <td class="elsa-py-2 pl-5">
 
-            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm">
+            <div class="elsa-mt-1 elsa-relative elsa-rounded-md elsa-shadow-sm elsa-text-box">
               <he-expression-editor
                 key={`expression-editor-${index}-${this.syntaxSwitchCount}-${this.keyId}`}
                 ref={el => expressionEditor = el}
@@ -157,7 +157,7 @@ export class HeSwitchCasesProperty {
               />
               <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">
                 <select onChange={e => this.onCaseSyntaxChanged(e, switchCase, expressionEditor)}
-                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md">
+                  class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-h-full elsa-py-0 elsa-pl-2 elsa-pr-7 elsa-border-transparent elsa-bg-transparent elsa-text-gray-500 sm:elsa-text-sm elsa-rounded-md elsa-select">
                   {supportedSyntaxes.map(supportedSyntax => {
                     const selected = supportedSyntax == syntax;
                     return <option selected={selected}>{supportedSyntax}</option>;

--- a/src/Elsa.Dashboard/wwwroot/css/site.css
+++ b/src/Elsa.Dashboard/wwwroot/css/site.css
@@ -215,3 +215,40 @@ elsa-modal-dialog > div > div > div:first-child {
   border-color: rgb(229 231 235) !important;
   border-width: 2px !important;
 }
+
+.elsa-select {
+  margin-right: 1em;
+  position:absolute;
+}
+
+.elsa-text-box {
+  width: 85%;
+}
+
+@media only screen and (max-width: 1800px) {
+  .elsa-text-box {
+    width: 90%;
+  }
+}
+
+@media only screen and (max-width: 1400px) {
+  .elsa-text-box {
+    width: 85%;
+  }
+}
+
+@media only screen and (max-width: 1200px) {
+  .elsa-text-box {
+    width: 80%;
+  }
+}
+@media only screen and (max-width: 1000px) {
+  .elsa-text-box {
+    width: 70%;
+  }
+}
+@media only screen and (max-width: 1200px) {
+  .elsa-text-box {
+    width: 60%;
+  }
+}


### PR DESCRIPTION
Unable to expand certain Text areas or Input fields due to the nested Dropdown within Elsa.
Have moved the Dropdown out of the field, and given enough padding on different screen sizes that this should remain on the page.
Now, the syntax selector will sit outside of a given input field, and the input fields can be resized to allow for lengthy Javascript input.

I did have a look at different options (i.e. Restyling or adjusting the Z-index of the resize element, but this seemed the cleanest option.  


