### PR TITLE
Bugfix/archived records not returned

### DIFF
--- a/src/Elsa.CustomWorkflow.Sdk/HttpClients/DataDictionaryHttpClient.cs
+++ b/src/Elsa.CustomWorkflow.Sdk/HttpClients/DataDictionaryHttpClient.cs
@@ -91,7 +91,8 @@ namespace Elsa.CustomWorkflow.Sdk.HttpClients
         public async Task<string?> LoadDataDictionary(string elsaServer, bool includeArchived = false)
         {
             string data;
-            string fullUri = $"{elsaServer}/activities/dictionary?includeArchived={includeArchived}" + "?t=" + DateTime.UtcNow.Ticks;
+            string uri = includeArchived ? "dictionary/archived" : "dictionary";
+            string fullUri = $"{elsaServer}/activities/{uri}?" + "t=" + DateTime.UtcNow.Ticks;
             var client = _httpClientFactory.CreateClient("DataDictionaryClient");
             AddAccessTokenToRequest(client);
             using (var response = await client

--- a/src/Elsa.CustomWorkflow.Sdk/HttpClients/ElsaServerHttpClient.cs
+++ b/src/Elsa.CustomWorkflow.Sdk/HttpClients/ElsaServerHttpClient.cs
@@ -289,7 +289,8 @@ namespace Elsa.CustomWorkflow.Sdk.HttpClients
         public async Task<string?> LoadDataDictionary(string elsaServer, bool includeArchived = false)
         {
             string data;
-            string fullUri = $"{elsaServer}/activities/dictionary?includeArchived={includeArchived}" + "?t=" + DateTime.UtcNow.Ticks;
+            string uri = includeArchived ? "dictionary/archived" : "dictionary";
+            string fullUri = $"{elsaServer}/activities/{uri}?" + "t=" + DateTime.UtcNow.Ticks;
             var client = _httpClientFactory.CreateClient("ElsaServerClient");
             AddAccessTokenToRequest(client);
             using (var response = await client

--- a/src/Elsa.Server.Tests/Features/Activities/ActivitiesControllerTests.cs
+++ b/src/Elsa.Server.Tests/Features/Activities/ActivitiesControllerTests.cs
@@ -82,7 +82,7 @@ namespace Elsa.Server.Tests.Features.Activities
             ActivitiesController controller = new ActivitiesController(mediatorMock.Object);
 
             //Act
-            var result = await controller.GetDataDictionary(false);
+            var result = await controller.GetDataDictionary();
 
             //Assert
             Assert.NotNull(result);
@@ -103,7 +103,7 @@ namespace Elsa.Server.Tests.Features.Activities
             ActivitiesController controller = new ActivitiesController(mediatorMock.Object);
 
             //Act
-            var result = await controller.GetDataDictionary(false);
+            var result = await controller.GetDataDictionary();
 
             //Assert
             Assert.NotNull(result);

--- a/src/Elsa.Server/Features/Activities/ActivitiesController.cs
+++ b/src/Elsa.Server/Features/Activities/ActivitiesController.cs
@@ -34,11 +34,26 @@ namespace Elsa.Server.Features.Activities
         }
 
         [HttpGet("dictionary")]
-        public async Task<IActionResult> GetDataDictionary(bool includeArchived)
+        public async Task<IActionResult> GetDataDictionary()
         {
             try
             {
-                string results = await _mediator.Send(new DataDictionaryCommand() { IncludeArchived = includeArchived});
+                string results = await _mediator.Send(new DataDictionaryCommand() { IncludeArchived = false});
+                return Ok(results);
+
+            }
+            catch (Exception e)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, e);
+            }
+        }
+
+        [HttpGet("dictionary/archived")]
+        public async Task<IActionResult> GetArchivedDataDictionary()
+        {
+            try
+            {
+                string results = await _mediator.Send(new DataDictionaryCommand() { IncludeArchived = true });
                 return Ok(results);
 
             }


### PR DESCRIPTION
Fix for bug that is preventing archived records from being displayed in the Data Dictionary management section.
Added additional endpoint and routing as route binding was not working, and had not been working for a while (Due to prior bug that had masked this).