### PR TITLE
Updated Handler and added unit tests

### DIFF
--- a/src/He.PipelineAssessment.UI.Tests/Features/SinglePipeline/Sync/SyncCommandHandlerTests.cs
+++ b/src/He.PipelineAssessment.UI.Tests/Features/SinglePipeline/Sync/SyncCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using He.PipelineAssessment.UI.Features.SinglePipeline.Sync;
 using Moq;
 using Xunit;
 using He.PipelineAssessment.Models.ViewModels;
+using He.PipelineAssessment.Models;
 
 namespace He.PipelineAssessment.UI.Tests.Features.SinglePipeline.Sync
 {
@@ -81,6 +82,84 @@ namespace He.PipelineAssessment.UI.Tests.Features.SinglePipeline.Sync
             Assert.Equal(assessmentsTobeAdded.Count, result.NewAssessmentCount);
             Assert.True(result.Synced);
             Assert.Equal(6, result.UpdatedAssessmentCount);
+        }
+
+        [Theory]
+        [AutoMoqData]
+
+        public async Task Handle_RemovesAssessmentRecords_GivenSignlePipelineDataDoesNotIncludeTheirReference(
+            int sharedId,
+            [Frozen] Mock<ISyncCommandHandlerHelper> syncCommandHandlerHelper,
+            [Frozen] Mock<ISinglePipelineProvider> singlePipelineService,
+            [Frozen] Mock<IAssessmentRepository> assessmentRepository,
+            List<Models.Assessment> assessmentsTobeAdded,
+            List<Models.Assessment> assessments,
+            List<SinglePipelineData> singlePipelineDataResponse,
+            List<AssessmentToolWorkflowInstance> workflowInstances,
+            SyncCommandHandler sut)
+        {
+            //Arrange
+            assessments.First().SpId = sharedId;
+            var startedAssessment = assessments.First(x => x.SpId != sharedId);
+            startedAssessment.AssessmentToolWorkflowInstances = workflowInstances;
+            singlePipelineDataResponse.First().sp_id = sharedId;
+            singlePipelineService.Setup(x => x.GetSinglePipelineData()).ReturnsAsync(singlePipelineDataResponse);
+
+            assessmentRepository.Setup(x => x.GetAssessments()).ReturnsAsync(assessments);
+
+            var sourceAssessmentSpIds = singlePipelineDataResponse.Select(x => x.sp_id!.Value).ToList();
+            var destinationAssessmentSpIdsThatHaveBeganAssessment = assessments.Where(x => x.AssessmentToolWorkflowInstances != null && x.AssessmentToolWorkflowInstances.Any())
+                        .Select(x => x.SpId).ToList();
+            var destinationAssessmentSpIdsThatHaveNotBeganAssessment = assessments.Where(x => x.AssessmentToolWorkflowInstances == null || x.AssessmentToolWorkflowInstances.Count == 0)
+                .Select(x => x.SpId).ToList();
+
+            var assessmentsToRemove = assessments.Where(x => !sourceAssessmentSpIds.Contains(x.SpId)).ToList();
+
+            var validDestinationAssessmentSpIdsThatHaveNotBeganAssessment = destinationAssessmentSpIdsThatHaveNotBeganAssessment.Except(assessmentsToRemove.Select(x => x.SpId)).ToList();
+            var destinationAssessmentSpIds = destinationAssessmentSpIdsThatHaveBeganAssessment.Concat(validDestinationAssessmentSpIdsThatHaveNotBeganAssessment).ToList();
+
+            syncCommandHandlerHelper.Setup(x => x.AssessmentsToBeAdded(sourceAssessmentSpIds, destinationAssessmentSpIds, singlePipelineDataResponse)).Returns(assessmentsTobeAdded);
+
+            syncCommandHandlerHelper.Setup(x => x.AssessmentsToBeRemoved(sourceAssessmentSpIds, destinationAssessmentSpIdsThatHaveNotBeganAssessment, assessments)).Returns(assessmentsToRemove);
+
+            var existingAssessments = destinationAssessmentSpIds.Intersect(sourceAssessmentSpIds).ToList();
+
+            syncCommandHandlerHelper.Setup(x => x.UpdateAssessments(assessments, existingAssessments, singlePipelineDataResponse)).Returns(6);
+
+            //Act
+            var result = await sut.Handle(It.IsAny<SyncCommand>(), CancellationToken.None);
+
+            //Assert
+            assessmentRepository.Verify(x => x.CreateAssessments(assessmentsTobeAdded), Times.Once);
+            Assert.NotNull(result);
+            Assert.IsType<SyncModel>(result);
+            Assert.Equal(assessmentsTobeAdded.Count, result.NewAssessmentCount);
+            Assert.True(result.Synced);
+            Assert.Equal(6, result.UpdatedAssessmentCount);
+        }
+
+        [Theory]
+        [AutoMoqData]
+
+        public void Helper_IdentifiesRecordsToRemoveFromPipelineAssessment(
+
+        List<Models.Assessment> assessments,
+        List<int> sampleIds,
+         SyncCommandHandlerHelper syncCommandHandlerHelper)
+        {
+            //Arrange
+            List<int> idsToRemove = assessments.Where(x => !sampleIds.Contains(x.SpId)).Select(y => y.SpId).ToList();
+            List<int> assessmentSpIds = assessments.Select(x => x.SpId).ToList();
+            //Act
+
+            List<Models.Assessment> assessmentsToRemove = syncCommandHandlerHelper.AssessmentsToBeRemoved(sampleIds, assessmentSpIds, assessments);
+
+            //Assert
+            Assert.Equal(idsToRemove.Count, assessmentsToRemove.Count);
+            foreach(Models.Assessment assessment in assessmentsToRemove)
+            {
+                Assert.Contains(assessment.SpId, idsToRemove);
+            }
         }
 
     }

--- a/src/He.PipelineAssessment.UI/Features/SinglePipeline/Sync/SyncCommandHandler.cs
+++ b/src/He.PipelineAssessment.UI/Features/SinglePipeline/Sync/SyncCommandHandler.cs
@@ -31,8 +31,17 @@ namespace He.PipelineAssessment.UI.Features.SinglePipeline.Sync
                     List<int> sourceAssessmentSpIds = data.Select(x => x.sp_id!.Value).ToList();
 
                     var destinationAssessments = await _assessmentRepository.GetAssessments();
-                    var destinationAssessmentSpIds = destinationAssessments.Select(x => x.SpId).ToList();
+                    var destinationAssessmentSpIdsThatHaveBeganAssessment = destinationAssessments.Where(x => x.AssessmentToolWorkflowInstances != null && x.AssessmentToolWorkflowInstances.Any())
+                        .Select(x => x.SpId).ToList();
+                    var destinationAssessmentSpIdsThatHaveNotBeganAssessment = destinationAssessments.Where(x => x.AssessmentToolWorkflowInstances == null || x.AssessmentToolWorkflowInstances.Count == 0)
+                        .Select(x => x.SpId).ToList();
+                    
+                    var assessmentsToBeRemoved = _syncCommandHandlerHelper.AssessmentsToBeRemoved(sourceAssessmentSpIds, destinationAssessmentSpIdsThatHaveNotBeganAssessment, destinationAssessments);
+                    
+                    assessmentsToBeRemoved.ForEach(x => destinationAssessments.Remove(x));
 
+                    var validDestinationAssessmentSpIdsThatHaveNotBeganAssessment = destinationAssessmentSpIdsThatHaveNotBeganAssessment.Except(assessmentsToBeRemoved.Select(x => x.SpId)).ToList();
+                    var destinationAssessmentSpIds = destinationAssessmentSpIdsThatHaveBeganAssessment.Concat(validDestinationAssessmentSpIdsThatHaveNotBeganAssessment).ToList();
                     var assessmentsToBeAdded = _syncCommandHandlerHelper.AssessmentsToBeAdded(sourceAssessmentSpIds, destinationAssessmentSpIds, data);
                     await _assessmentRepository.CreateAssessments(assessmentsToBeAdded);
 

--- a/src/He.PipelineAssessment.UI/Features/SinglePipeline/Sync/SyncCommandHandlerHelper.cs
+++ b/src/He.PipelineAssessment.UI/Features/SinglePipeline/Sync/SyncCommandHandlerHelper.cs
@@ -1,10 +1,12 @@
 ﻿using He.PipelineAssessment.Data.SinglePipeline;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace He.PipelineAssessment.UI.Features.SinglePipeline.Sync
 {
     public interface ISyncCommandHandlerHelper
     {
         List<Models.Assessment> AssessmentsToBeAdded(List<int> sourceAssessmentSpIds, List<int> destinationAssessmentSpIds, List<SinglePipelineData> sourcSinglePipelineData);
+        List<Models.Assessment> AssessmentsToBeRemoved(List<int> sourceAssessmentSpIds, List<int> destinationAssessmentSpIds, List<Models.Assessment> singlePipelineData);
         int UpdateAssessments(List<Models.Assessment> destinationAssessments, List<int> existingAssessments, List<SinglePipelineData> data);
     }
 
@@ -52,6 +54,19 @@ namespace He.PipelineAssessment.UI.Features.SinglePipeline.Sync
 
             return assessmentsToBeAdded;
         }
+
+        public List<Models.Assessment> AssessmentsToBeRemoved(List<int> sourceAssessmentSpIds, List<int> destinationAssessmentSpIds, List<Models.Assessment> assessments)
+        {
+            List<int> idsToBeRemoved = new List<int>();
+            idsToBeRemoved = destinationAssessmentSpIds.Except(sourceAssessmentSpIds).ToList();
+            List<Models.Assessment> assessmentsToBeRemoved = new List<Models.Assessment>();
+            if (idsToBeRemoved.Count > 0)
+            {
+                assessmentsToBeRemoved = assessments.Where(x => idsToBeRemoved.Contains(x.SpId)).ToList();
+            }
+            return assessmentsToBeRemoved;
+        }
+
         public int UpdateAssessments(List<Models.Assessment> destinationAssessments, List<int> existingAssessments, List<SinglePipelineData> data)
         {
             var count = 0;


### PR DESCRIPTION
Fix to remove assessments that no longer meet the entry criteria as part of the updates to the Sync.
As part of the sync handler we have now added a bit of code to check the existing assessments that have not started any workflows, and see if their SpId matches those of the assessments drawn from single pipeline.  If they don't, they are removed.  