### PR TITLE
Work setting up the extended pcs fields

### DIFF
--- a/src/He.PipelineAssessment.Data/PCSProfile/EsriPCSProfileResponse.cs
+++ b/src/He.PipelineAssessment.Data/PCSProfile/EsriPCSProfileResponse.cs
@@ -13,6 +13,15 @@
         public decimal? year_5_expend_fc { get; set; }
         public decimal? year_6_expend_fc { get; set; }
         public decimal? year_7_expend_fc { get; set; }
+        public decimal? year_8_expend_fc { get; set; }
+        public decimal? year_9_expend_fc { get; set; }
+        public decimal? year_10_expend_fc { get; set; }
+        public decimal? year_11_expend_fc { get; set; }
+        public decimal? year_12_expend_fc { get; set; }
+        public decimal? year_13_expend_fc { get; set; }
+        public decimal? year_14_expend_fc { get; set; }
+        public decimal? year_15_expend_fc { get; set; }
+
         public decimal? total_expend_fc { get; set; }
         public decimal? total_expend_fc_sr { get; set; }
         public decimal? total_expend_ac { get; set; }
@@ -24,6 +33,14 @@
         public decimal? year_5_receipt_fc { get; set; }
         public decimal? year_6_receipt_fc { get; set; }
         public decimal? year_7_receipt_fc { get; set; }
+        public decimal? year_8_receipt_fc { get; set; }
+        public decimal? year_9_receipt_fc { get; set; }
+        public decimal? year_10_receipt_fc { get; set; }
+        public decimal? year_11_receipt_fc { get; set; }
+        public decimal? year_12_receipt_fc { get; set; }
+        public decimal? year_13_receipt_fc { get; set; }
+        public decimal? year_14_receipt_fc { get; set; }
+        public decimal? year_15_receipt_fc { get; set; }
         public decimal? total_receipt_fc { get; set; }
         public decimal? total_receipt_fc_sr { get; set; }
         public decimal? total_receipt_ac { get; set; }
@@ -40,8 +57,11 @@
         public decimal? year_8_comp_fc { get; set; }
         public decimal? year_9_comp_fc { get; set; }
         public decimal? year_10_comp_fc { get; set; }
+        public decimal? year_11_comp_fc { get; set; }
+        public decimal? year_12_comp_fc { get; set; }
         public decimal? total_comp_fc { get; set; }
         public decimal? total_comp_fc_sr { get; set; }
+        public decimal? future_years_comp_fc { get; set; }
         public decimal? total_comp_ac { get; set; }
         public decimal? year_0_af_comp_fc { get; set; }
         public decimal? year_0_af_comp_act { get; set; }
@@ -56,7 +76,10 @@
         public decimal? year_8_af_comp_fc { get; set; }
         public decimal? year_9_af_comp_fc { get; set; }
         public decimal? year_10_af_comp_fc { get; set; }
+        public decimal? year_11_af_comp_fc { get; set; }
+        public decimal? year_12_af_comp_fc { get; set; }
         public decimal? total_af_comp_fc { get; set; }
+        public decimal? future_years_af_comp_fc { get; set; }
         public decimal? total_af_comp_fc_sr { get; set; }
         public decimal? total_af_comp_ac { get; set; }
         public string? fund_recovery { get; set; }


### PR DESCRIPTION
Added additional fields to PCS profile for purposes of drawing in the new fields from ESRI/IDCT.
No additional changes needed to parse/update and no additional unit tests required.