### PR TITLE
increment build number

### DIFF
--- a/src/He.PipelineAssessment.UI/azure-pipelines-build-semver.yml
+++ b/src/He.PipelineAssessment.UI/azure-pipelines-build-semver.yml
@@ -14,8 +14,8 @@ parameters:
     default: false
 
 variables:
-  buildMajor: 0
-  buildMinor: 0
+  buildMajor: 1
+  buildMinor: 1
   buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
 
 pool: 'vmss-ado-chs-nonprod-001'


### PR DESCRIPTION
This increments the build number for the tags to ensure it is in line with other Evolve projects. This is the base number before Developers will then decide the incrementation moving forward.