### PR TITLE
New semantic version build and deploy pipelines

### DIFF
--- a/azure-pipelines-ver-increment-check.yml
+++ b/azure-pipelines-ver-increment-check.yml
@@ -1,0 +1,15 @@
+trigger: none 
+
+pr:
+  branches:
+    include:
+    - main
+
+resources:
+  repositories:
+  - repository: templates
+    type: git
+    name: 'Cloud Hosting Service/Templates'
+
+stages:
+- template: semver-increment-check.yml@templates

--- a/src/Elsa.Dashboard/azure-pipelines-build.yml
+++ b/src/Elsa.Dashboard/azure-pipelines-build.yml
@@ -1,0 +1,45 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  branches:
+    include:
+    - main
+    
+parameters:
+  - name: forcePushToProd
+    displayName: Force Push to Production
+    type: boolean
+    default: false
+variables:
+
+  buildMajor: 0
+  buildMinor: 0
+  buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
+
+name: $(buildMajor).$(buildMinor).$(Rev:r)-elsadashboard.$(buildBranch)
+# Build and Push
+
+pool:
+  vmImage: 'ubuntu-22.04'
+
+resources:
+  repositories:
+  - repository: he-workflow
+    type: git
+    name: 'Common Components (Agile Board)/He.Workflow'   
+    ref: 'feature/semver'
+  - repository: templates
+    type: git
+    name: 'Cloud Hosting Service/Templates'   
+    ref: 'master'
+
+stages:
+- template: azure-pipelines-elsadashboard-build.yml@he-workflow

--- a/src/Elsa.Dashboard/azure-pipelines-build.yml
+++ b/src/Elsa.Dashboard/azure-pipelines-build.yml
@@ -20,8 +20,8 @@ parameters:
     default: false
 variables:
 
-  buildMajor: 0
-  buildMinor: 0
+  buildMajor: 1
+  buildMinor: 1
   buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
 
 name: $(buildMajor).$(buildMinor).$(Rev:r)-elsadashboard.$(buildBranch)
@@ -35,7 +35,6 @@ resources:
   - repository: he-workflow
     type: git
     name: 'Common Components (Agile Board)/He.Workflow'   
-    ref: 'feature/semver'
   - repository: templates
     type: git
     name: 'Cloud Hosting Service/Templates'   

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -8,6 +8,11 @@ trigger:
     include:
       - main
 
+pr:
+  branches:
+    include:
+    - main
+    
 parameters:
   - name: forcePushToProd
     displayName: Force Push to Production

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -37,4 +37,4 @@ resources:
     ref: 'master'
 
 stages:
-- template: azure-pipelines-build.yml@he-workflow
+- template: azure-pipelines-elsaserver-build.yml@he-workflow

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -20,8 +20,8 @@ parameters:
     default: false
 variables:
 
-  buildMajor: 0
-  buildMinor: 0
+  buildMajor: 1
+  buildMinor: 1
   buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
 
 name: $(buildMajor).$(buildMinor).$(Rev:r)-elsaserver.$(buildBranch)
@@ -35,7 +35,6 @@ resources:
   - repository: he-workflow
     type: git
     name: 'Common Components (Agile Board)/He.Workflow'   
-    ref: 'feature/semver'
   - repository: templates
     type: git
     name: 'Cloud Hosting Service/Templates'   

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -4,7 +4,23 @@
 # https://aka.ms/yaml
 
 trigger:
-  - none
+  branches:
+    include:
+      - main
+
+parameters:
+  - name: forcePushToProd
+    displayName: Force Push to Production
+    type: boolean
+    default: false
+variables:
+
+  buildMajor: 0
+  buildMinor: 0
+  buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
+
+name: $(buildMajor).$(buildMinor).$(Rev:r)-elsaserver.$(buildBranch)
+# Build and Push
 
 pool:
   vmImage: 'ubuntu-22.04'
@@ -14,7 +30,7 @@ resources:
   - repository: he-workflow
     type: git
     name: 'Common Components (Agile Board)/He.Workflow'   
-    ref: 'main'
+    ref: 'feature/semver'
   - repository: templates
     type: git
     name: 'Cloud Hosting Service/Templates'   


### PR DESCRIPTION
This migrates the elsa workflow system over to the new semantic version pipelines. Due to this the "Server" and "Dashboard" need to be split so each app has its own semversion.

[https://dev.azure.com/homesengland/Cloud Hosting Service/_wiki/wikis/Cloud-Hosting-Service.wiki/8971/Deploy-applications-using-semantic-versioning](https://dev.azure.com/homesengland/Cloud%20Hosting%20Service/_wiki/wikis/Cloud-Hosting-Service.wiki/8971/Deploy-applications-using-semantic-versioning)

The new pipelines are

he-workflow-elsaserver-build
he-workflow-elsaserver-deploy
he-workflow-elsadashboard-build
he-workflow-elsadashboard-deploy
he-workflow-semver-increment-check

This needs to be merged in along side https://dev.azure.com/homesengland/Common%20Components%20(Agile%20Board)/_git/He.Workflow/pullrequest/9997