### PR TITLE
Add new custom convention to set newtonsoft json serlializer when usi…

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.10" />
@@ -58,6 +59,6 @@
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-	<PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/Elsa.Server/Extensions/CustomElsaNewtonsoftJsonConvention.cs
+++ b/src/Elsa.Server/Extensions/CustomElsaNewtonsoftJsonConvention.cs
@@ -1,0 +1,31 @@
+﻿using Elsa.Server.Api.Attributes;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace Elsa.Server.Extensions
+{
+    public class CustomElsaNewtonsoftJsonConvention : IControllerModelConvention
+    {
+        public void Apply(ControllerModel controller)
+        {
+            if (ShouldApplyConvention(controller))
+            {
+                NewtonsoftJsonFormatterAttribute newtonsoftJsonFormatterAttribute = new NewtonsoftJsonFormatterAttribute();
+                newtonsoftJsonFormatterAttribute.Apply(controller);
+                controller.Filters.Add(newtonsoftJsonFormatterAttribute);
+            }
+        }
+
+        private bool ShouldApplyConvention(ControllerModel controller)
+        {
+            if (controller != null && 
+                (controller.ControllerType?.FullName?.StartsWith("Elsa.Server.Features.Dashboard.CustomList") == true ||
+                (controller.ControllerType?.FullName?.StartsWith("Elsa.Server.Features.Dashboard.CustomHistory") == true)))
+
+            {
+                return !controller.Attributes.Any((object x) => x.GetType() == typeof(NewtonsoftJsonFormatterAttribute));
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Elsa.Server/Program.cs
+++ b/src/Elsa.Server/Program.cs
@@ -47,6 +47,7 @@ using Elsa.CustomActivities.Activities.SinglePipelineExtendedDataSource;
 using Elsa.CustomActivities.Activities.ReturnToActivity;
 using Elsa.CustomWorkflow.Sdk.DataDictionaryHelpers;
 using Elsa.Server.DataDictionaryAccessors;
+using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
 var elsaConnectionString = builder.Configuration.GetConnectionString("Elsa");
@@ -79,7 +80,7 @@ bool useCache = (Convert.ToBoolean(builder.Configuration["Redis:UseCache"]) && !
 logger.LogInformation($"Using Cache: {useCache}");
 // Elsa services.
 builder.Services
-    .AddElsa(elsa => elsa
+    .AddElsa(elsa => elsa    
         .UseEntityFrameworkPersistenceWithCache(ef => ef.UseSqlServer(elsaConnectionString!, typeof(Elsa.Persistence.EntityFramework.SqlServer.Migrations.Initial)), true, useCache)
         .NoCoreActivities()
         .AddActivity<SinglePipelineDataSource>()
@@ -133,6 +134,10 @@ else
 }
 // Elsa API endpoints.
 builder.Services.AddElsaApiEndpoints();
+builder.Services.AddMvc(delegate (MvcOptions options)
+{
+    options.Conventions.Add(new CustomElsaNewtonsoftJsonConvention());
+}); 
 
 //Custom method.  Register new Script Handlers here.
 builder.Services.AddCustomElsaScriptHandlers();

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -22,7 +22,7 @@ parameters:
 
 variables:
   buildMajor: 1
-  buildMinor: 3
+  buildMinor: 4
   buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
 
 name: $(buildMajor).$(buildMinor).$(Rev:r)-elsaserver.$(buildBranch)


### PR DESCRIPTION
In Elsa Service Program.cs we call AddElsaApiEndpoints extension method. In Elsa 2.2.1 this was setting AddNewtonsoftJson on all controllers, but this was updated in later version to only use the Newtonsoft Json serialiser for controllers in Elsa.Server.Api. This was done by setting a Mvc contention. Our custom controllers fell outside this criteria, therefore the error is thrown. I have added a new convention to set Newtonsoft Json serialiser to be used for our custom controllers. 