### PR TITLE
Fix for Infinite Json Looping in Elsa Server

### DIFF
--- a/src/Elsa.Server/Program.cs
+++ b/src/Elsa.Server/Program.cs
@@ -48,6 +48,7 @@ using Elsa.CustomActivities.Activities.ReturnToActivity;
 using Elsa.CustomWorkflow.Sdk.DataDictionaryHelpers;
 using Elsa.Server.DataDictionaryAccessors;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 var elsaConnectionString = builder.Configuration.GetConnectionString("Elsa");
@@ -225,6 +226,10 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     });
 
 builder.Services.AddEsriHttpClients(builder.Configuration, builder.Environment.IsDevelopment());
+
+//Fix for the infinite JSON loop following an update in Elsa 2.14.1
+builder.Services.AddControllers().AddJsonOptions(x =>
+                x.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles);
 
 //HibernatingRhinos.Profiler.Appender.EntityFramework.EntityFrameworkProfiler.Initialize();
 var app = builder.Build();

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -22,7 +22,7 @@ parameters:
 
 variables:
   buildMajor: 1
-  buildMinor: 4
+  buildMinor: 5
   buildBranch: $[replace(variables['Build.SourceBranch'], '/', '.')]
 
 name: $(buildMajor).$(buildMinor).$(Rev:r)-elsaserver.$(buildBranch)


### PR DESCRIPTION
Following the update to Elsa v 2.14.1 we encountered an issue where infinite loops stopped being handled by Elsa Server.  We are unsure as to what has caused this as we have not investigated Elsa directly - this could also be down to other changes handled as part of the upgrade to Elsa, within the package Migration.

We were able to put an override into the Program.cs to enforce JsonOptions across controllers to ignore Cycles.  This has resolved the problem.