### PR TITLE
Fix for handling null value for workflow instances

### DIFF
--- a/src/He.PipelineAssessment.UI/Features/Workflow/LoadQuestionScreen/LoadQuestionScreenRequestHandler.cs
+++ b/src/He.PipelineAssessment.UI/Features/Workflow/LoadQuestionScreen/LoadQuestionScreenRequestHandler.cs
@@ -82,8 +82,11 @@ namespace He.PipelineAssessment.UI.Features.Workflow.LoadQuestionScreen
                     result!.IsAuthorised = true;
                     result!.AssessmentId = assessmentWorkflowInstance.AssessmentId;
                     result!.WorkflowDefinitionId = assessmentWorkflowInstance.WorkflowDefinitionId;
-                    result!.AssessmentToolName = assessmentWorkflowInstance.AssessmentToolWorkflow.AssessmentTool.Name;
-                    result!.AssessmentToolWorkflowName = assessmentWorkflowInstance.AssessmentToolWorkflow.Name;
+                    if (assessmentWorkflowInstance.AssessmentToolWorkflow != null)
+                    {
+                        result!.AssessmentToolName = assessmentWorkflowInstance.AssessmentToolWorkflow.AssessmentTool.Name;
+                        result!.AssessmentToolWorkflowName = assessmentWorkflowInstance.AssessmentToolWorkflow.Name;
+                    }
 
                     PageHeaderHelper.PopulatePageHeaderInformation(result, assessmentWorkflowInstance);
                     return await Task.FromResult(result);


### PR DESCRIPTION
In the event a workflow instance is null (Such as when we are using the Test Screen) this will prevent crashes for null values