### PR TITLE
migration to update GetEconomistAssessments Stored proc to include In…

### DIFF
--- a/src/Elsa.Dashboard/azure-pipelines-build.yml
+++ b/src/Elsa.Dashboard/azure-pipelines-build.yml
@@ -23,7 +23,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 2
+  buildPatch: 3
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: elsadashboard
 name: $(buildMajor).$(buildMinor).$(buildPatch)-$(Rev:r)-$(identifier).$(buildBranch)

--- a/src/Elsa.Server/azure-pipelines-build.yml
+++ b/src/Elsa.Server/azure-pipelines-build.yml
@@ -23,7 +23,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 3
+  buildPatch: 4
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: elsaserver
  

--- a/src/He.PipelineAssessment.Infrastructure/He.PipelineAssessment.Infrastructure.csproj
+++ b/src/He.PipelineAssessment.Infrastructure/He.PipelineAssessment.Infrastructure.csproj
@@ -109,6 +109,7 @@
     <EmbeddedResource Include="Migrations\20260122141647_UpdateSPsToReturnSpIdForInterventions\GetAssessmentInterventionListByAssessmentId.sql" />
     <EmbeddedResource Include="Migrations\20260122141647_UpdateSPsToReturnSpIdForInterventions\GetInterventionList.sql" />
     <EmbeddedResource Include="Migrations\20260223134239_AddPcsAndInternalReferenceToAssessment\GetAssessments.sql" />
+    <EmbeddedResource Include="Migrations\20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference\GetEconomistAssessments.sql" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/He.PipelineAssessment.Infrastructure/Migrations/20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference.Designer.cs
+++ b/src/He.PipelineAssessment.Infrastructure/Migrations/20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference.Designer.cs
@@ -4,6 +4,7 @@ using He.PipelineAssessment.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace He.PipelineAssessment.Infrastructure.Migrations
 {
     [DbContext(typeof(PipelineAssessmentContext))]
-    partial class PipelineAssessmentContextModelSnapshot : ModelSnapshot
+    [Migration("20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference")]
+    partial class UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/He.PipelineAssessment.Infrastructure/Migrations/20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference.cs
+++ b/src/He.PipelineAssessment.Infrastructure/Migrations/20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System.Reflection;
+
+#nullable disable
+
+namespace He.PipelineAssessment.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var sqlFiles = assembly.GetManifestResourceNames().Where(file =>
+                file.Contains(
+                    "20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference.GetEconomistAssessments.sql"));
+            foreach (var sqlFile in sqlFiles)
+            {
+                using (Stream stream = assembly.GetManifestResourceStream(sqlFile))
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    var sqlScript = reader.ReadToEnd();
+                    migrationBuilder.Sql($"EXEC(N'{sqlScript}')");
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            var dropGetEconomistAssessments = "DROP PROC GetEconomistAssessments";
+            migrationBuilder.Sql(dropGetEconomistAssessments);
+        }
+    }
+}

--- a/src/He.PipelineAssessment.Infrastructure/Migrations/20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference/GetEconomistAssessments.sql
+++ b/src/He.PipelineAssessment.Infrastructure/Migrations/20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference/GetEconomistAssessments.sql
@@ -1,0 +1,66 @@
+CREATE OR ALTER PROCEDURE [dbo].[GetEconomistAssessments]
+
+AS
+BEGIN
+SELECT 
+    a.[Id],
+    a.[SpId],
+    a.[SiteName],
+    a.[Counterparty],
+    a.[Reference],
+    a.[ProjectManager],
+    a.[ProjectManagerEmail],
+    a.[LocalAuthority],
+    a.[FundingAsk],
+    a.[NumberOfHomes],
+    a.[ValidData],
+    a.[CreatedDateTime],
+    a.[InternalReference],
+    (
+    	select top 1 
+    	atwi.[LastModifiedDateTime] 
+    	from [AssessmentToolWorkflowInstance] atwi 
+    	where a.Id = atwi.AssessmentId 
+    	order by 
+    	[LastModifiedDateTime] desc
+    ) as [LastModifiedDateTime],
+    economistAssessments.EconomistWorkflowStatus as [Status],
+    a.SensitiveStatus
+    FROM [dbo].[Assessment] a 
+    INNER JOIN 
+    (
+    	SELECT
+    	ATWI.AssessmentId as AssessmentId , AT.Name + '' Started'' as EconomistWorkflowStatus
+    	FROM [dbo].[AssessmentToolWorkflowInstance] ATWI
+    	INNER JOIN [dbo].AssessmentToolWorkflow ATW ON ATWI.WorkflowDefinitionId = ATW.WorkflowDefinitionId AND ATW.IsEconomistWorkflow=1
+		INNER JOIN [dbo].AssessmentTool AT ON (ATW.AssessmentToolId = AT.Id AND (AT.Status IS NULL OR AT.Status != ''Deleted''))
+    	WHERE ATWI.Status = ''Draft''
+
+    	UNION
+
+    	SELECT 
+    	ATWINW.AssessmentId as AssessmentId , AT.Name + '' Not Started'' as EconomistWorkflowStatus
+    	FROM [dbo].[AssessmentToolInstanceNextWorkflow] ATWINW
+    	INNER JOIN [dbo].AssessmentToolWorkflow ATW ON ATWINW.NextWorkflowDefinitionId = ATW.WorkflowDefinitionId AND ATW.IsEconomistWorkflow=1
+    	LEFT JOIN [dbo].[AssessmentToolWorkflowInstance] ATWI on ATWI.AssessmentId = ATWINW.AssessmentId AND  ATWINW.NextWorkflowDefinitionId = ATWI.WorkflowDefinitionId
+		INNER JOIN [dbo].AssessmentTool AT ON (ATW.AssessmentToolId = AT.Id AND (AT.Status IS NULL OR AT.Status != ''Deleted''))
+    	WHERE ATWI.AssessmentId is null
+
+    ) as  economistAssessments ON a.Id = economistAssessments.AssessmentId
+    GROUP BY
+    a.[Id],
+    a.[SpId],
+    a.[SiteName],
+    a.[Counterparty],
+    a.[Reference],
+    a.[ProjectManager],
+    a.[ProjectManagerEmail],
+    a.[LocalAuthority],
+    a.[FundingAsk],
+    a.[NumberOfHomes],
+    a.[ValidData],
+    a.[CreatedDateTime],
+    a.[InternalReference],
+    economistAssessments.EconomistWorkflowStatus,
+    a.SensitiveStatus
+END 

--- a/src/He.PipelineAssessment.UI/azure-pipelines-build-semver.yml
+++ b/src/He.PipelineAssessment.UI/azure-pipelines-build-semver.yml
@@ -28,7 +28,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 6
+  buildPatch: 7
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: pipasmt
 


### PR DESCRIPTION
This pull request introduces a new database migration to update the `GetEconomistAssessments` stored procedure so that it now includes the `InternalReference` field in its results. This change ensures that assessments retrieved for economists will have this additional piece of information available. The migration includes the SQL script for the updated stored procedure, the migration logic to apply and revert the change, and updates the Entity Framework model snapshot accordingly.

**Database Migration: Update to Economist Assessments**

* Added a new migration `20260226125640_UpdatingGetEconomistAssessmentsStoredProcedureToIncludeInternalReference` that updates the `GetEconomistAssessments` stored procedure to include the `InternalReference` column in its select statement. [[1]](diffhunk://#diff-2901b120c5d4084c1163df51d5016d02b9b6150f2bffba931e5d74ff92d20d7dR1-R36) [[2]](diffhunk://#diff-62237db88b6f18a53b9ba7cf5bc0886a6fc230281be69660c25c128976bd6689R1-R66)
* Embedded the new SQL script for the updated stored procedure in the project file (`He.PipelineAssessment.Infrastructure.csproj`).
* Updated the Entity Framework model snapshot to include the `InternalReference` property for the `Assessment` entity.